### PR TITLE
Update docker.md | Add missing mongodb port

### DIFF
--- a/install-guides/docker.md
+++ b/install-guides/docker.md
@@ -29,6 +29,7 @@ docker run --rm \
     --name mongo \
     -e TZ="Etc/UTC" \
     --user 1000:1000 \
+    -p 27017:27017 \
     -v /<host_folder_db>:/data/db \
     mongo
 ```


### PR DESCRIPTION
added bridge networking to the docker run example to match the accompanying docker-compose format.