### PR TITLE
Clarify the requirement to have a forward slash for radarr and sonarr configs

### DIFF
--- a/configuration/radarr.md
+++ b/configuration/radarr.md
@@ -26,7 +26,7 @@ Click on `Add New`
 
 After clicking `Add New` you need to specify all your Radarr settings and give it a friendly name you can recognize. Your `host` and `port` fields will vary depending on what installation method you chose.
 
-If you are hosting Radarr behind a reverse proxy and have configured a base URL, you need to specify it on the `URL Base` field. If this all sounds like alien speak, you don't have to write anything there.
+If you are hosting Radarr behind a reverse proxy and have configured a base URL, you need to specify it on the `URL Base` field. If this all sounds like alien speak, you don't have to write anything there. Make sure the base URL has a preceding slash like `/radarr`.
 
 You can obtain your Radarr API key by going to your Radarr instance and clicking on `Settings > General`.
 

--- a/configuration/sonarr-1.md
+++ b/configuration/sonarr-1.md
@@ -28,7 +28,7 @@ Click on `Add New`
 
 After clicking `Add New` you need to specify all your Sonarr settings and give it a friendly name you can recognize. Your `host` and `port` fields will vary depending on what installation method you chose.
 
-If you are hosting Sonarr behind a reverse proxy and have configured a base URL, you need to specify it on the `URL Base` field. If this all sounds like alien speak, you don't have to write anything there.
+If you are hosting Sonarr behind a reverse proxy and have configured a base URL, you need to specify it on the `URL Base` field. If this all sounds like alien speak, you don't have to write anything there. Make sure the base URL has a preceding slash like `/sonarr`.
 
 You can obtain your Sonarr API key by going to your Sonarr instance and clicking on `Settings > General`.
 


### PR DESCRIPTION
This is to clarify the right way to add the Base URL. I have opened a issue to track this and add additional validation or auto correction within the code in issue https://github.com/petio-team/petio/issues/360